### PR TITLE
add "id={this.props.id}" to ReactTabulator init

### DIFF
--- a/src/lib/components/DashTabulator.react.js
+++ b/src/lib/components/DashTabulator.react.js
@@ -139,6 +139,7 @@ export default class DashTabulator extends Component {
             <div>
                 {downloadButton}{clearFilterButton}
             <ReactTabulator
+                id={this.props.id}
                 ref={ref => (this.ref = ref)}
                 data={data}
                 columns={columns}


### PR DESCRIPTION
as of right now I think the "ID" attribute of the main Tabulator div in the browser is not passed on from the python DashTabulator object initialisation adding the "id={this.props.id}" to ReactTabulator init fixed the behavior for me